### PR TITLE
Validation: allow Harvest Tree/Stone without entity ID

### DIFF
--- a/backend/PlanBackend.Application/Validation/ActionSpec.cs
+++ b/backend/PlanBackend.Application/Validation/ActionSpec.cs
@@ -6,12 +6,15 @@ public static class ActionSpec
         new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
         {
             ["MoveTo"]    = ["x", "y"],
-            ["Harvest"]   = ["target_id"],
             ["Construct"] = ["scene", "x", "y"],
         };
 
+    // Harvest is not in RequiredParams because it uses either target_id or resource_type.
+    public static readonly IReadOnlySet<string> HarvestResourceTypes =
+        new HashSet<string>(["tree", "stone"], StringComparer.OrdinalIgnoreCase);
+
     public static readonly IReadOnlySet<string> SupportedActions =
-        new HashSet<string>(RequiredParams.Keys, StringComparer.OrdinalIgnoreCase);
+        new HashSet<string>(RequiredParams.Keys.Append("Harvest"), StringComparer.OrdinalIgnoreCase);
 
     // Parameters that must parse as float (duration is optional, validated only when present)
     public static readonly IReadOnlyDictionary<string, string[]> FloatParams =
@@ -24,6 +27,5 @@ public static class ActionSpec
     public static readonly IReadOnlyDictionary<string, string[]> IntParams =
         new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
         {
-            ["Harvest"] = ["target_id"],
         };
 }

--- a/backend/PlanBackend.Application/Validation/PlanValidator.cs
+++ b/backend/PlanBackend.Application/Validation/PlanValidator.cs
@@ -29,12 +29,15 @@ public class PlanValidator(ISenseQueryClient senseClient)
                     continue;
                 }
 
-                foreach (var param in ActionSpec.RequiredParams[step.ActionType])
+                if (ActionSpec.RequiredParams.TryGetValue(step.ActionType, out var reqPs))
                 {
-                    if (!step.Parameters.TryGetValue(param, out var val) || string.IsNullOrWhiteSpace(val))
-                        errors.Add(
-                            $"unit '{unitPlan.UnitId}' step {step.StepIndex}: " +
-                            $"action '{step.ActionType}' missing required parameter '{param}'.");
+                    foreach (var param in reqPs)
+                    {
+                        if (!step.Parameters.TryGetValue(param, out var val) || string.IsNullOrWhiteSpace(val))
+                            errors.Add(
+                                $"unit '{unitPlan.UnitId}' step {step.StepIndex}: " +
+                                $"action '{step.ActionType}' missing required parameter '{param}'.");
+                    }
                 }
 
                 if (ActionSpec.FloatParams.TryGetValue(step.ActionType, out var floatPs))
@@ -62,6 +65,29 @@ public class PlanValidator(ISenseQueryClient senseClient)
                                 $"unit '{unitPlan.UnitId}' step {step.StepIndex}: " +
                                 $"parameter '{param}' must be an integer (got '{val}').");
                     }
+                }
+
+                if (step.ActionType.Equals("Harvest", StringComparison.OrdinalIgnoreCase))
+                {
+                    var hasTargetId = step.Parameters.TryGetValue("target_id", out var tid)
+                                      && !string.IsNullOrWhiteSpace(tid);
+                    var hasResourceType = step.Parameters.TryGetValue("resource_type", out var rt)
+                                          && !string.IsNullOrWhiteSpace(rt);
+
+                    if (!hasTargetId && !hasResourceType)
+                        errors.Add(
+                            $"unit '{unitPlan.UnitId}' step {step.StepIndex}: " +
+                            $"Harvest requires either 'target_id' (integer) or 'resource_type' " +
+                            $"(one of: {string.Join(", ", ActionSpec.HarvestResourceTypes)}).");
+                    else if (hasTargetId && !int.TryParse(tid, out _))
+                        errors.Add(
+                            $"unit '{unitPlan.UnitId}' step {step.StepIndex}: " +
+                            $"parameter 'target_id' must be an integer (got '{tid}').");
+                    else if (hasResourceType && !ActionSpec.HarvestResourceTypes.Contains(rt!))
+                        errors.Add(
+                            $"unit '{unitPlan.UnitId}' step {step.StepIndex}: " +
+                            $"'resource_type' must be one of: " +
+                            $"{string.Join(", ", ActionSpec.HarvestResourceTypes)} (got '{rt}').");
                 }
             }
         }
@@ -94,7 +120,7 @@ public class PlanValidator(ISenseQueryClient senseClient)
                         s.ActionType.Equals("Harvest", StringComparison.OrdinalIgnoreCase)))
                     {
                         var targetId = step.Parameters.GetValueOrDefault("target_id", "");
-                        if (!resourceIds.Contains(targetId))
+                        if (!string.IsNullOrWhiteSpace(targetId) && !resourceIds.Contains(targetId))
                             errors.Add(
                                 $"unit '{unitPlan.UnitId}' step {step.StepIndex}: " +
                                 $"resource '{targetId}' does not exist in the current game state.");


### PR DESCRIPTION
ActionSpec: remove target_id from RequiredParams/IntParams for Harvest, add HarvestResourceTypes (tree, stone), keep Harvest in SupportedActions. PlanValidator: replace flat required-param check for Harvest with an either/or rule (target_id integer OR resource_type known type). Phase 2 resource-existence check is skipped when resource_type is used since Core resolves the nearest resource at runtime.