### PR TITLE
feat(validation): update condition predicates to CamelCase vocabulary

### DIFF
--- a/backend/PlanBackend.Application/Validation/ActionSpec.cs
+++ b/backend/PlanBackend.Application/Validation/ActionSpec.cs
@@ -18,7 +18,8 @@ public static class ActionSpec
 
     public static readonly IReadOnlySet<string> ConditionPrefixes =
         new HashSet<string>(
-            ["enemy_nearby", "resources_nearby", "stockpile.wood", "stockpile.stone", "unit.health"],
+            ["EnemyWithin", "NoEnemyWithin", "HpBelow", "HpAbove",
+             "idle", "busy", "always", "wood", "stone"],
             StringComparer.OrdinalIgnoreCase);
 
     // Parameters that must parse as float (duration is optional, validated only when present)


### PR DESCRIPTION
Replace old condition prefixes with new vocabulary matching the DSL: EnemyWithin, NoEnemyWithin, HpBelow, HpAbove, idle, busy, always, wood, stone — covers comparisons like 'wood > stone' and 'wood > 50'