### PR TITLE
feat(planning): add configurable rate limiting on plan submissions

### DIFF
--- a/backend/PlanBackend.Api/Program.cs
+++ b/backend/PlanBackend.Api/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using PlanBackend.Application.Interfaces;
+using PlanBackend.Application.Options;
 using PlanBackend.Application.Services;
 using PlanBackend.Application.Validation;
 using PlanBackend.Infrastructure;
@@ -31,6 +32,10 @@ else
 
 builder.Services.AddScoped<IPlanRepository, PlanRepository>();
 builder.Services.AddScoped<PlanValidator>();
+builder.Services.AddSingleton(new PlanServiceOptions
+{
+    RateLimitSeconds = builder.Configuration.GetValue<int>("PlanRateLimitSeconds", 30)
+});
 builder.Services.AddScoped<PlanService>();
 
 builder.Services.AddControllers();

--- a/backend/PlanBackend.Api/appsettings.json
+++ b/backend/PlanBackend.Api/appsettings.json
@@ -8,5 +8,6 @@
   "AllowedHosts": "*",
   "CoreBaseUrl": "http://127.0.0.1:8085",
   "UseRedis": false,
-  "RedisConnection": "localhost:6379"
+  "RedisConnection": "localhost:6379",
+  "PlanRateLimitSeconds": 30
 }

--- a/backend/PlanBackend.Application/Interfaces/IPlanRepository.cs
+++ b/backend/PlanBackend.Application/Interfaces/IPlanRepository.cs
@@ -10,4 +10,5 @@ public interface IPlanRepository
     Task<List<GamePlanSummary>> GetGamePlanHistoryAsync(string gameId, string playerId);
     Task<GamePlan?> GetGamePlanByVersionAsync(string gameId, string playerId, int version);
     Task<GamePlan?> GetActiveGamePlanAsync(string gameId, string playerId);
+    Task<DateTime?> GetLastSubmissionTimeAsync(string gameId, string playerId);
 }

--- a/backend/PlanBackend.Application/Options/PlanServiceOptions.cs
+++ b/backend/PlanBackend.Application/Options/PlanServiceOptions.cs
@@ -1,0 +1,6 @@
+namespace PlanBackend.Application.Options;
+
+public class PlanServiceOptions
+{
+    public int RateLimitSeconds { get; init; } = 30;
+}

--- a/backend/PlanBackend.Application/Services/PlanService.cs
+++ b/backend/PlanBackend.Application/Services/PlanService.cs
@@ -1,15 +1,21 @@
 using PlanBackend.Application.DTOs;
 using PlanBackend.Application.Interfaces;
+using PlanBackend.Application.Options;
 using PlanBackend.Application.Validation;
 using PlanBackend.Domain.Models;
 
 namespace PlanBackend.Application.Services;
 
-public class PlanService(IPlanRepository repository, ICoreNotifier notifier, PlanValidator validator)
+public class PlanService(
+    IPlanRepository repository,
+    ICoreNotifier notifier,
+    PlanValidator validator,
+    PlanServiceOptions options)
 {
     private readonly IPlanRepository _repository = repository;
     private readonly ICoreNotifier   _notifier   = notifier;
     private readonly PlanValidator   _validator  = validator;
+    private readonly int _rateLimitSeconds = options.RateLimitSeconds;
 
     public async Task<SubmitResult> SubmitPlanAsync(GamePlan plan)
     {
@@ -19,6 +25,24 @@ public class PlanService(IPlanRepository repository, ICoreNotifier notifier, Pla
         var errors = await _validator.ValidateAsync(plan);
         if (errors.Count > 0)
             return new SubmitResult { Success = false, Errors = errors };
+
+        if (_rateLimitSeconds > 0)
+        {
+            var lastSubmission = await _repository.GetLastSubmissionTimeAsync(plan.GameId, plan.PlayerId);
+            if (lastSubmission.HasValue)
+            {
+                var elapsed = (DateTime.UtcNow - lastSubmission.Value).TotalSeconds;
+                if (elapsed < _rateLimitSeconds)
+                {
+                    var wait = (int)Math.Ceiling(_rateLimitSeconds - elapsed);
+                    return new SubmitResult
+                    {
+                        Success = false,
+                        Errors  = [$"Rate limit: wait {wait}s before submitting again."]
+                    };
+                }
+            }
+        }
 
         var history    = await _repository.GetGamePlanHistoryAsync(plan.GameId, plan.PlayerId);
         plan.Version   = history.Count == 0 ? 1 : history.Max(h => h.Version) + 1;

--- a/backend/PlanBackend.Infrastructure/PlanRepository.cs
+++ b/backend/PlanBackend.Infrastructure/PlanRepository.cs
@@ -105,4 +105,13 @@ public class PlanRepository(PlanDbContext context) : IPlanRepository
 
         return JsonSerializer.Deserialize<GamePlan>(entity.GamePlanJson);
     }
+
+    public async Task<DateTime?> GetLastSubmissionTimeAsync(string gameId, string playerId)
+    {
+        return await _context.GamePlans
+            .Where(g => g.GameId == gameId && g.PlayerId == playerId)
+            .OrderByDescending(g => g.CreatedAt)
+            .Select(g => (DateTime?)g.CreatedAt)
+            .FirstOrDefaultAsync();
+    }
 }


### PR DESCRIPTION
Rejects submissions within the configured interval and returns a wait-time message. PlanServiceOptions keeps IConfiguration out of the Application layer. Set PlanRateLimitSeconds=0 to disable.